### PR TITLE
Perf fix: moved to `std::forward_list<>`.

### DIFF
--- a/Blocks/Persistence/persistence.h
+++ b/Blocks/Persistence/persistence.h
@@ -27,8 +27,8 @@ SOFTWARE.
 
 #include <cassert>
 #include <chrono>
+#include <forward_list>
 #include <functional>
-#include <list>
 #include <mutex>
 #include <thread>
 
@@ -39,10 +39,56 @@ SOFTWARE.
 #include "../../Bricks/util/clone.h"
 #include "../../Bricks/util/waitable_terminate_signal.h"
 
+// TODO(dkorolev): Either include our profiler or eliminate profiling altogether. Sync w/ Max.
+#ifndef PROFILER_SCOPE
+#define PROFILER_SCOPE(x)
+#endif
+
 namespace blocks {
 namespace persistence {
 
 namespace impl {
+
+class ThreeStageMutex {
+ public:
+  struct TopLevelScopedLock {
+    explicit TopLevelScopedLock(ThreeStageMutex& parent) : guard_(parent.stage1_) {}
+    std::lock_guard<std::mutex> guard_;
+  };
+
+  struct ThreeStagesScopedLock {
+    explicit ThreeStagesScopedLock(ThreeStageMutex& parent) : parent_(parent) { parent_.stage1_.lock(); }
+    void AdvanceToStageTwo() {
+      assert(stage_ == 1);
+      parent_.stage2_.lock();
+      parent_.stage1_.unlock();
+      stage_ = 2;
+    }
+    void AdvanceToStageThree() {
+      assert(stage_ == 2);
+      parent_.stage3_.lock();
+      parent_.stage2_.unlock();
+      stage_ = 3;
+    }
+    ~ThreeStagesScopedLock() {
+      assert(stage_ == 3);
+      parent_.stage3_.unlock();
+    }
+    int stage_ = 1;
+    ThreeStageMutex& parent_;
+  };
+
+  struct InnerLevelScopedUniqueLock {
+    explicit InnerLevelScopedUniqueLock(ThreeStageMutex& parent) : unique_guard_(parent.stage3_) {}
+    std::unique_lock<std::mutex>& GetUniqueLock() { return unique_guard_; }
+    std::unique_lock<std::mutex> unique_guard_;
+  };
+
+ private:
+  std::mutex stage1_;  // Update internal container.
+  std::mutex stage2_;  // Publish the newly saved entry to the persistence layer.
+  std::mutex stage3_;  // Notify the listeners that a new entry is ready.
+};
 
 template <class PERSISTENCE_LAYER, typename ENTRY, class CLONER>
 class Logic : bricks::WaitableTerminateSignalBulkNotifier {
@@ -50,7 +96,9 @@ class Logic : bricks::WaitableTerminateSignalBulkNotifier {
   template <typename... EXTRA_PARAMS>
   explicit Logic(EXTRA_PARAMS&&... extra_params)
       : persistence_layer_(std::forward<EXTRA_PARAMS>(extra_params)...) {
-    persistence_layer_.Replay([this](ENTRY&& e) { list_.push_back(std::move(e)); });
+    persistence_layer_.Replay([this](ENTRY&& e) {
+      ListPushBackImpl(std::move(e));
+    });
   }
 
   Logic(const Logic&) = delete;
@@ -61,8 +109,10 @@ class Logic : bricks::WaitableTerminateSignalBulkNotifier {
       bool at_end = true;
       size_t index = 0u;
       size_t total = 0u;
-      typename std::list<ENTRY>::const_iterator iterator;
-      static Cursor Next(const Cursor& current, const std::list<ENTRY>& exclusively_accessed_list) {
+      typename std::forward_list<ENTRY>::const_iterator iterator;
+      static Cursor Next(const Cursor& current,
+                         const std::forward_list<ENTRY>& exclusively_accessed_list,
+                         const size_t& exclusively_accessed_list_size) {
         Cursor next;
         if (current.at_end) {
           next.iterator = exclusively_accessed_list.begin();
@@ -73,7 +123,7 @@ class Logic : bricks::WaitableTerminateSignalBulkNotifier {
           ++next.iterator;
           next.index = current.index + 1u;
         }
-        next.total = exclusively_accessed_list.size();
+        next.total = exclusively_accessed_list_size;
         next.at_end = (next.iterator == exclusively_accessed_list.end());
         return next;
       }
@@ -82,8 +132,9 @@ class Logic : bricks::WaitableTerminateSignalBulkNotifier {
 
     const size_t size_at_start = [this]() {
       // LOCKED: Get the number of entries before sending them to the listener.
-      std::lock_guard<std::mutex> lock(mutex_);
-      return list_.size();
+      PROFILER_SCOPE("SyncScanAllEntries() `size_at_start`");
+      ThreeStageMutex::TopLevelScopedLock lock(three_stage_mutex_);
+      return list_size_;
     }();
     bool replay_done = false;
 
@@ -121,8 +172,10 @@ class Logic : bricks::WaitableTerminateSignalBulkNotifier {
         }
         next = [&current, this]() {
           // LOCKED: Move the cursor forward.
-          std::lock_guard<std::mutex> lock(mutex_);
-          return Cursor::Next(current, list_);
+          PROFILER_SCOPE("SyncScanAllEntries(), advance cursor");
+          ThreeStageMutex::TopLevelScopedLock lock(three_stage_mutex_);
+          PROFILER_SCOPE("lock acquired");
+          return Cursor::Next(current, list_, std::ref(list_size_));
         }();
         if (next.at_end) {
           // Wait until one of two events take place:
@@ -131,10 +184,12 @@ class Logic : bricks::WaitableTerminateSignalBulkNotifier {
           // 2) The listener thread has been externally requested to terminate.
           [this, &next, &waitable_terminate_signal]() {
             // LOCKED: Wait for either new data to become available or for an external termination request.
-            std::unique_lock<std::mutex> unique_lock(mutex_);
+            PROFILER_SCOPE("SyncScanAllEntries(), wait for new data");
+            ThreeStageMutex::InnerLevelScopedUniqueLock unique_lock(three_stage_mutex_);
+            PROFILER_SCOPE("lock acquired");
             bricks::WaitableTerminateSignalBulkNotifier::Scope scope(this, waitable_terminate_signal);
-            waitable_terminate_signal.WaitUntil(unique_lock,
-                                                [this, &next]() { return list_.size() > next.total; });
+            waitable_terminate_signal.WaitUntil(unique_lock.GetUniqueLock(),
+                                                [this, &next]() { return list_size_ > next.total; });
           }();
         }
       } while (next.at_end);
@@ -145,62 +200,189 @@ class Logic : bricks::WaitableTerminateSignalBulkNotifier {
  protected:
   // Deliberately keep these two signatures and not one with `std::forward<>` to ensure the type is right.
   size_t DoPublish(const ENTRY& entry) {
-    std::lock_guard<std::mutex> lock(mutex_);
-    list_.push_back(entry);
-    persistence_layer_.Publish(entry);
-    NotifyAllOfExternalWaitableEvent();
-    return list_.size() - 1u;
+    PROFILER_SCOPE("DoPublish(const ENTRY&)");
+    ThreeStageMutex::ThreeStagesScopedLock lock(three_stage_mutex_);
+    {
+      PROFILER_SCOPE("lock acquired");
+      const size_t result = list_size_;
+      {
+        PROFILER_SCOPE("push_back");
+        ListPushBackImpl(entry);
+      }
+      {
+        PROFILER_SCOPE("promote lock 1->2");
+        lock.AdvanceToStageTwo();
+      }
+      {
+        PROFILER_SCOPE("publish");
+        persistence_layer_.Publish(entry);
+      }
+      {
+        PROFILER_SCOPE("promote lock 2->3");
+        lock.AdvanceToStageThree();
+      }
+      {
+        PROFILER_SCOPE("notify");
+        NotifyAllOfExternalWaitableEvent();
+      }
+      return result;
+    }
   }
   size_t DoPublish(ENTRY&& entry) {
-    std::lock_guard<std::mutex> lock(mutex_);
-    list_.push_back(std::move(entry));
-    persistence_layer_.Publish(static_cast<const ENTRY&>(list_.back()));
-    NotifyAllOfExternalWaitableEvent();
-    return list_.size() - 1u;
+    PROFILER_SCOPE("DoPublish(E&&)");
+    ThreeStageMutex::ThreeStagesScopedLock lock(three_stage_mutex_);
+    {
+      PROFILER_SCOPE("lock acquired");
+      const size_t result = list_size_;
+      {
+        PROFILER_SCOPE("push_back, std::move");
+        ListPushBackImpl(std::move(entry));
+      }
+      const ENTRY& pushed_entry = *list_back_;
+      {
+        PROFILER_SCOPE("promote lock 1->2");
+        lock.AdvanceToStageTwo();
+      }
+      {
+        PROFILER_SCOPE("publish");
+        persistence_layer_.Publish(pushed_entry);
+      }
+      {
+        PROFILER_SCOPE("1->3");
+        lock.AdvanceToStageThree();
+      }
+      {
+        PROFILER_SCOPE("notify");
+        NotifyAllOfExternalWaitableEvent();
+      }
+      return result;
+    }
   }
 
   template <typename DERIVED_ENTRY>
   size_t DoPublishDerived(const DERIVED_ENTRY& entry) {
     static_assert(bricks::can_be_stored_in_unique_ptr<ENTRY, DERIVED_ENTRY>::value, "");
-    std::lock_guard<std::mutex> lock(mutex_);
 
-    // `std::unique_ptr<DERIVED_ENTRY>` can be implicitly converted into `std::unique_ptr<ENTRY>`,
-    // if `ENTRY` is the base class for `DERIVED_ENTRY`.
-    // This requires the destructor of `BASE` to be virtual, which is the case for Current and Yoda.
-    std::unique_ptr<DERIVED_ENTRY> copy(make_unique<DERIVED_ENTRY>());
-    *copy = bricks::DefaultCloneFunction<DERIVED_ENTRY>()(entry);
-    list_.push_back(std::move(copy));
-    persistence_layer_.Publish(list_.back());
+    PROFILER_SCOPE("DoPublishDerived(const DERIVED_ENTRY&)");
+    ThreeStageMutex::ThreeStagesScopedLock lock(three_stage_mutex_);
 
-    // A simple construction, commented out below, would require `DERIVED_ENTRY` to define
-    // the copy constructor. Instead, we go with Current-friendly clone implementation above.
-    // COMMENTED OUT: persistence_layer_.Publish(entry);
-    // COMMENTED OUT: list_.push_back(std::move(make_unique<DERIVED_ENTRY>(entry)));
+    {
+      PROFILER_SCOPE("lock acquired");
 
-    // Another, semantically correct yet inefficient way, is to use JavaScript-style cloning.
-    // COMMENTED OUT: persistence_layer_.Publish(entry);
-    // COMMENTED OUT: list_.push_back(ParseJSON<ENTRY>(JSON(WithBaseType<typename
-    // ENTRY::element_type>(entry))));
+      // `std::unique_ptr<DERIVED_ENTRY>` can be implicitly converted into `std::unique_ptr<ENTRY>`,
+      // if `ENTRY` is the base class for `DERIVED_ENTRY`.
+      // This requires the destructor of `BASE` to be virtual, which is the case for Current and Yoda.
+      std::unique_ptr<DERIVED_ENTRY> copy(make_unique<DERIVED_ENTRY>());
+      {
+        PROFILER_SCOPE("clone");
+        *copy = bricks::DefaultCloneFunction<DERIVED_ENTRY>()(entry);
+      }
+      const size_t result = list_size_;
+      {
+        PROFILER_SCOPE("push_back, std::move");
+        ListPushBackImpl(std::move(copy));
+      }
+      const ENTRY& pushed_entry = *list_back_;
+      {
+        PROFILER_SCOPE("promote lock 1->2");
+        lock.AdvanceToStageTwo();
+      }
+      {
+        PROFILER_SCOPE("publish");
+        persistence_layer_.Publish(pushed_entry);
 
-    NotifyAllOfExternalWaitableEvent();
-    return list_.size() - 1u;
+        // A simple construction, commented out below, would require `DERIVED_ENTRY` to define
+        // the copy constructor. Instead, we go with Current-friendly clone implementation above.
+        // COMMENTED OUT: persistence_layer_.Publish(entry);
+        // COMMENTED OUT: list_.push_back(std::move(make_unique<DERIVED_ENTRY>(entry)));
+
+        // Another, semantically correct yet inefficient way, is to use JavaScript-style cloning.
+        // COMMENTED OUT: persistence_layer_.Publish(entry);
+        // COMMENTED OUT: list_.push_back(ParseJSON<ENTRY>(JSON(WithBaseType<typename
+        // ENTRY::element_type>(entry))));
+      }
+      {
+        PROFILER_SCOPE("promote lock 2->3");
+        lock.AdvanceToStageThree();
+      }
+
+      {
+        PROFILER_SCOPE("notify");
+        NotifyAllOfExternalWaitableEvent();
+      }
+      return result;
+    }
   }
 
   template <typename... ARGS>
   size_t DoEmplace(ARGS&&... args) {
-    std::lock_guard<std::mutex> lock(mutex_);
-    list_.emplace_back(std::forward<ARGS>(args)...);
-    persistence_layer_.Publish(list_.back());
-    NotifyAllOfExternalWaitableEvent();
-    return list_.size() - 1u;
+    PROFILER_SCOPE("DoEmplace(...)");
+    ThreeStageMutex::ThreeStagesScopedLock lock(three_stage_mutex_);
+    {
+      PROFILER_SCOPE("lock acquired");
+      const size_t result = list_size_;
+      {
+        PROFILER_SCOPE("emplace_back");
+        ListEmplaceBackImpl(std::forward<ARGS>(args)...);
+      }
+      const ENTRY& pushed_entry = *list_back_;
+      {
+        PROFILER_SCOPE("promote lock 1->2");
+        lock.AdvanceToStageTwo();
+      }
+      {
+        PROFILER_SCOPE("publish");
+        persistence_layer_.Publish(pushed_entry);
+      }
+      {
+        PROFILER_SCOPE("promote lock promote lock 2->3");
+        lock.AdvanceToStageThree();
+      }
+      {
+        PROFILER_SCOPE("notify");
+        NotifyAllOfExternalWaitableEvent();
+      }
+      return result;
+    }
+  }
+
+ private:
+  // `std::forward_list<>` and its size + iterator management.
+  template <typename E>
+  void ListPushBackImpl(E&& e) {
+    if (list_size_) {
+      list_.insert_after(list_back_, std::forward<E>(e));
+      ++list_back_;
+    } else {
+      list_.push_front(std::forward<E>(e));
+      list_back_ = list_.begin();
+    }
+    ++list_size_;
+  }
+  template <typename... ARGS>
+  void ListEmplaceBackImpl(ARGS&&... args) {
+    if (list_size_) {
+      list_.emplace_after(list_back_, std::forward<ARGS>(args)...);
+      ++list_back_;
+    } else {
+      list_.emplace_front(std::forward<ARGS>(args)...);
+      list_back_ = list_.begin();
+    }
+    ++list_size_;
   }
 
  private:
   static_assert(ss::IsEntryPublisher<PERSISTENCE_LAYER, ENTRY>::value, "");
   PERSISTENCE_LAYER persistence_layer_;
 
-  std::list<ENTRY> list_;  // `std::list<>` does not invalidate iterators as new elements are added.
-  std::mutex mutex_;
+  // `std::forward_list<>` does not invalidate iterators as new elements are added.
+  // Explicitly refrain from using an `std::list<>` due to its `.size()` complexity troubles on gcc/Linux.
+  std::forward_list<ENTRY> list_;
+  size_t list_size_ = 0;
+  typename std::forward_list<ENTRY>::const_iterator list_back_;  // Only valid iff `list_size_` > 0.
+
+  // To release the locks for the `std::forward_list<>` and the persistence layer ASAP.
+  ThreeStageMutex three_stage_mutex_;
 };
 
 // The implementation of a "publisher into nowhere".


### PR DESCRIPTION
Hi @mzhurovich

After https://github.com/c5t/Current/pull/225 is in, here's the change that fixes `v2`'s performance.

Let's chat about checking it in, as well as the location of the profiling code (which is `#ifdef`-ed away in non-profiling modes, so I suggest we keep it in perf-critical places just in case).

Thanks,
Dima